### PR TITLE
Satin API also fixes the namespace bug + jitpack support.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 17.0.2-open
+  - sdk use java 17.0.2-open

--- a/src/main/java/com/nettakrim/souper_secret_settings/SouperSecretSettingsMixinPlugin.java
+++ b/src/main/java/com/nettakrim/souper_secret_settings/SouperSecretSettingsMixinPlugin.java
@@ -21,10 +21,10 @@ public class SouperSecretSettingsMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        //architectury api fixes the namespace bug themselves, so soup's mixin can be disabled
-        if(mixinClassName.equals("com.nettakrim.souper_secret_settings.mixin.JsonEffectShaderProgramMixin")) {
-            return !FabricLoader.getInstance().isModLoaded("architectury");
-        }
+        //architectury api and satin both fix the namespace bug themselves, so soup's mixin can be disabled
+        if (mixinClassName.equals("com.nettakrim.souper_secret_settings.mixin.JsonEffectShaderProgramMixin")) {
+            return FabricLoader.getInstance().isModLoaded("architectury") || FabricLoader.getInstance().isModLoaded("satin");
+        };
         return true;
     }
 

--- a/src/main/java/com/nettakrim/souper_secret_settings/SouperSecretSettingsMixinPlugin.java
+++ b/src/main/java/com/nettakrim/souper_secret_settings/SouperSecretSettingsMixinPlugin.java
@@ -24,7 +24,7 @@ public class SouperSecretSettingsMixinPlugin implements IMixinConfigPlugin {
         //architectury api and satin both fix the namespace bug themselves, so soup's mixin can be disabled
         if (mixinClassName.equals("com.nettakrim.souper_secret_settings.mixin.JsonEffectShaderProgramMixin")) {
             return FabricLoader.getInstance().isModLoaded("architectury") || FabricLoader.getInstance().isModLoaded("satin");
-        };
+        }
         return true;
     }
 


### PR DESCRIPTION
- Satin API also fixes the namespace bug so soup's mixin will now disable for both "architectury" and "satin".
- additionally, added jitpack support for use in development environments.