### PR TITLE
Added "disable_screen_mode" for Perspective.

### DIFF
--- a/src/main/resources/assets/souper_secret_settings/shaders.json
+++ b/src/main/resources/assets/souper_secret_settings/shaders.json
@@ -28,6 +28,10 @@
                 "antialias",
                 "creeper",
                 "spider"                
+            ],
+            "disable_screen_mode": [
+                "flip",
+                "spider"
             ]
         }
     ]

--- a/src/main/resources/resourcepacks/expanded_shaders/assets/souper_secret_settings/shaders.json
+++ b/src/main/resources/resourcepacks/expanded_shaders/assets/souper_secret_settings/shaders.json
@@ -35,6 +35,18 @@
                 "fractal",
                 "bevel",
                 "depth_outline"
+            ],
+            "disable_screen_mode": [
+                "sequins",
+                "kaleidoscope",
+                "ghost",
+                "dramatic",
+                "rotate",
+                "cinematic",
+                "horror",
+                "out_of_bounds",
+                "fractal",
+                "depth_outline"
             ]
         }
     ],


### PR DESCRIPTION
Perspective 1.1.0-beta.6 is going to add a new "disable_screen_mode" option that stops shaders being rendered on screen mode as not all shaders work great with the gui.