### PR TITLE
render location fallbacks

### DIFF
--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/anaglyph.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/anaglyph.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/ascii.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/ascii.json
@@ -1,5 +1,8 @@
 {
-    "disable_ui_rendertype": true,
+    "enabled": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/ascii.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/ascii.json
@@ -1,5 +1,4 @@
 {
-    "enabled": false,
     "fallback_when_over_ui": false,
     "fallback_when_under_ui": false,
     "photosensitive": false,

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/autumnal.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/autumnal.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/bevel.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/bevel.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/blobs_outline.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/blobs_outline.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur", "bloom" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/blobs_rounded.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/blobs_rounded.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/blobs_square.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/blobs_square.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/bloom_color.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/bloom_color.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "bloom" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/bloom_spike.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/bloom_spike.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "bloom" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/brightness.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/brightness.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/checkerboard.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/checkerboard.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/cinematic.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/cinematic.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/collapse.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/collapse.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "animated" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/color_bleed.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/color_bleed.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/color_blind.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/color_blind.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/color_shuffle.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/color_shuffle.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/contrast.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/contrast.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/crunch.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/crunch.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/crystallize.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/crystallize.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/depth_outline.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/depth_outline.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/dissolve.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/dissolve.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/dither.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/dither.json
@@ -1,5 +1,4 @@
 {
-    "enabled": false,
     "fallback_when_over_ui": false,
     "fallback_when_under_ui": false,
     "photosensitive": false,

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/dither.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/dither.json
@@ -1,5 +1,8 @@
 {
-    "disable_ui_rendertype": false,
+    "enabled": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/dramatic.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/dramatic.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/emboss.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/emboss.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/film_grain.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/film_grain.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "animated", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/fisheye.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/fisheye.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/fractal.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/fractal.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/frigid.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/frigid.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/gel.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/gel.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/ghost.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/ghost.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/glass.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/glass.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/glitchy.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/glitchy.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "animated" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/gray_echo.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/gray_echo.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/half_invert.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/half_invert.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/halftone.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/halftone.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/halftone_rgb.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/halftone_rgb.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/harsh_dither.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/harsh_dither.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/highpass.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/highpass.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/horror.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/horror.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/hsv_map.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/hsv_map.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/hue_perceptual.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/hue_perceptual.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/hue_rotate.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/hue_rotate.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/hyperspace.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/hyperspace.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/infrared.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/infrared.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/interference.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/interference.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/julia.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/julia.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/kaleidoscope.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/kaleidoscope.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/life.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/life.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/mandelbrot.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/mandelbrot.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/motion_blur.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/motion_blur.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/mouse.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/mouse.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/noise3d.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/noise3d.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/normalise.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/normalise.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/offset_blobs.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/offset_blobs.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "retro", "dither" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/offset_print.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/offset_print.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "retro", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/out_of_bounds.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/out_of_bounds.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/palette_dither.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/palette_dither.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/patchwork.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/patchwork.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/pendulum.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/pendulum.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/plants.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/plants.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/plasma.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/plasma.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/quilted.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/quilted.json
@@ -1,5 +1,4 @@
 {
-    "enabled": false,
     "fallback_when_over_ui": false,
     "fallback_when_under_ui": false,
     "photosensitive": false,

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/quilted.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/quilted.json
@@ -1,5 +1,8 @@
 {
-    "disable_ui_rendertype": true,
+    "enabled": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/reflect.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/reflect.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/retro.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/retro.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/rings.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/rings.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/rolling_shutter.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/rolling_shutter.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/rotate.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/rotate.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/s2xe.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/s2xe.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/sepia.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/sepia.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "dither", "retro", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/sequins.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/sequins.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/shadows.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/shadows.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/sorting.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/sorting.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/split_tone.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/split_tone.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/stereogram.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/stereogram.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "animated", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/stern.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/stern.json
@@ -1,5 +1,4 @@
 {
-    "enabled": false,
     "fallback_when_over_ui": false,
     "fallback_when_under_ui": false,
     "photosensitive": false,

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/stern.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/stern.json
@@ -1,5 +1,8 @@
 {
-    "disable_ui_rendertype": false,
+    "enabled": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/stripe.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/stripe.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "depth", "persistent" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/suspicious.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/suspicious.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/temporal_blur.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/temporal_blur.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "persistent", "blur" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/texture_map.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/texture_map.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/thermal.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/thermal.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "outline" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/toon.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/toon.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "retro" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/toxic_waste.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/toxic_waste.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/uv_map.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/uv_map.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/voronoi.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/voronoi.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "blur", "persistent" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/walls.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/walls.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": true,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp", "depth" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/washed_out.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/washed_out.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/watermelon.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/watermelon.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/windows.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/windows.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/xor.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/xor.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": false,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "filter" ]

--- a/src/main/resources/resourcepacks/soup/assets/soup/luminance/zigzag.json
+++ b/src/main/resources/resourcepacks/soup/assets/soup/luminance/zigzag.json
@@ -1,5 +1,7 @@
 {
-    "disable_ui_rendertype": false,
+    "fallback_when_over_ui": true,
+    "fallback_when_under_ui": false,
+    "photosensitive": false,
     "custom": {
         "souper_secret_settings": {
             "groups": [ "edible", "warp" ]


### PR DESCRIPTION
- Updated shader fallbacks
---

This can also be found in [Luminance/LuminanceShaders.md](https://github.com/mclegoman/luminance/blob/development-26.1/LuminanceShaders.md)

# Shaders included with Souper Secret Settings

## Extra Soup
| Identifier           | Fallback Over UI | Fallback Under UI | Photosensitive | Notes                                                                                                                                                 |
|----------------------|------------------|-------------------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
| soup:anaglyph        | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:ascii           | false            | false             | false          | Untested.                                                                                                                                             |
| soup:autumnal        | false            | false             | false          |                                                                                                                                                       |
| soup:bevel           | false            | false             | false          |                                                                                                                                                       |
| soup:blobs_outline   | true             | false             | false          | Text is extreamly difficult to read.                                                                                                                  |
| soup:blobs_rounded   | true             | false             | false          | Everything is hard to see...                                                                                                                          |
| soup:blobs_square    | false            | false             | false          | Slightly difficult to read but still mostly readable, just overly bold.                                                                               |
| soup:bloom_color     | false            | false             | false          | Everything is so shiny- it's readable enough if a user needed to disable it.                                                                          |
| soup:bloom_spike     | false            | false             | false          |                                                                                                                                                       |
| soup:brightness      | false            | false             | false          |                                                                                                                                                       |
| soup:checkerboard    | true             | false             | false          | Whilst you *can* still see everything in it's original place, it does have overlapping which could make it difficult to see.                          |
| soup:cinematic       | true             | false             | false          | Covers two sides, which includes the done button in settings screens when using a 16:9 aspect ratio.                                                  |
| soup:collapse        | false            | false             | false          |                                                                                                                                                       |
| soup:color_bleed     | false            | false             | false          |                                                                                                                                                       |
| soup:color_blind     | false            | false             | false          |                                                                                                                                                       |
| soup:color_shuffle   | false            | false             | false          | MY EYES BURN NOW; can be slightly difficult to read (especially transparent elements), but still useable.                                             |
| soup:contrast        | false            | false             | false          |                                                                                                                                                       |
| soup:crunch          | false            | false             | false          | I'm unsure. I *can* still read most of the text when covered on the ui, which i think is enough to be able to disable, but some text is hard to read. |
| soup:crystallize     | true             | false             | false          | Really cool effect, but text is totally unreadable.                                                                                                   |
| soup:depth_outline   | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:dissolve        | false            | false             | false          | If you wait a couple seconds, things become readable again. Scrolling is a nightmare though.                                                          |
| soup:dither          | false            | false             | false          | Untested.                                                                                                                                             |
| soup:dramatic        | false            | false             | false          |                                                                                                                                                       |
| soup:emboss          | false            | false             | false          |                                                                                                                                                       |
| soup:film_grain      | false            | false             | false          |                                                                                                                                                       |
| soup:fisheye         | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |
| soup:fractal         | true             | false             | false          | Obscures ui elements.                                                                                                                                 |
| soup:frigid          | false            | false             | false          |                                                                                                                                                       |
| soup:gel             | false            | false             | false          | If you give it a few seconds, most ui element backgrounds go black.                                                                                   |
| soup:ghost           | true             | false             | false          | Even dead, I cannot see.                                                                                                                              |
| soup:glass           | false            | false             | false          | Text is not readable.                                                                                                                                 |
| soup:glitchy         | false            | false             | false          | I don't think this one is working as intended.                                                                                                        |
| soup:gray_echo       | true             | false             | false          | and i thought color shuffle burnt my eyes... I cannot see. help.                                                                                      |
| soup:half_invert     | false            | false             | false          |                                                                                                                                                       |
| soup:halftone        | true             | false             | false          | Text is not readable.                                                                                                                                 |
| soup:halftone_rgb    | true             | false             | false          | Text is not readable.                                                                                                                                 |
| soup:harsh_dither    | false            | false             | false          |                                                                                                                                                       |
| soup:highpass        | false            | false             | false          |                                                                                                                                                       |
| soup:horror          | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:hsv_map         | false            | false             | false          |                                                                                                                                                       |
| soup:hue_perceptual  | false            | false             | false          |                                                                                                                                                       |
| soup:hue_rotate      | false            | false             | false          |                                                                                                                                                       |
| soup:hyperspace      | true             | false             | false          | I think i'm about to go where no man has gone before... Text isn't readable.                                                                          |
| soup:infrared        | false            | false             | false          |                                                                                                                                                       |
| soup:interference    | false            | false             | false          | I don't think this one is working as intended.                                                                                                        |
| soup:julia           | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |
| soup:kaleidoscope    | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |
| soup:life            | false            | false             | false          | Transparent elements aren't visible, could be slightly difficult to navigate however I think it's still useable.                                      |
| soup:mandelbrot      | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |
| soup:motion_blur     | false            | false             | false          | okay this one is hillarious, it moves your hotbar around with you.                                                                                    |
| soup:mouse           | false            | false             | false          | when moving, colours at the bottom of the screen can flicker. I think it's minor, but still could effect photosentitive peoples.                      |
| soup:noise3d         | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:normalise       | true             | false             | false          | Text on buttons is not readable.                                                                                                                      |
| soup:offset_blobs    | true             | false             | false          | Text is not readable.                                                                                                                                 |
| soup:offset_print    | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:out_of_bounds   | false            | false             | false          |                                                                                                                                                       |
| soup:palette_dither  | false            | false             | false          |                                                                                                                                                       |
| soup:patchwork       | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:pendulum        | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |
| soup:plants          | false            | false             | false          |                                                                                                                                                       |
| soup:plasma          | false            | false             | false          | MAJOR PHOTOSENTIVE WARNING RN HOLY- I assume this is a bug whilst updating.                                                                           |
| soup:quilted         | false            | false             | false          | Untested.                                                                                                                                             |
| soup:reflect         | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:retro           | false            | false             | false          |                                                                                                                                                       |
| soup:rings           | true             | false             | false          | Text is not readable.                                                                                                                                 |
| soup:rolling_shutter | false            | false             | false          | You will need to give it a couple seconds every time you update something to be able to see it, otherwise it's okay.                                  |
| soup:rotate          | true             | false             | false          | Currently broken, however iirc this one is like flip but sideways.                                                                                    |
| soup:s2xe            | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |
| soup:sepia           | false            | false             | false          | Some ui text is difficult to read, however it's mostly useable.                                                                                       |
| soup:sequins         | true             | false             | false          | Text is not readable.                                                                                                                                 |
| soup:shadows         | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:sorting         | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:split_tone      | false            | false             | false          |                                                                                                                                                       |
| soup:stereogram      | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:stern           | false            | false             | false          | Untested.                                                                                                                                             |
| soup:stripe          | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:suspicious      | false            | false             | false          |                                                                                                                                                       |
| soup:temporal_blur   | false            | false             | false          | Mostly fine, scrolling screens are okay after a second.                                                                                               |
| soup:texture_map     | false            | false             | false          | Uses depth, will automatically fallback on non-depth render locations.                                                                                |
| soup:thermal         | false            | false             | false          | Useable, however harsh to the eyes.                                                                                                                   |
| soup:toon            | true             | false             | false          | Text is not readable.                                                                                                                                 |
| soup:toxic_waste     | false            | false             | false          |                                                                                                                                                       |
| soup:uv_map          | true             | false             | false          | Text is really dark, barely visible.                                                                                                                  |
| soup:voronoi         | false            | false             | false          |                                                                                                                                                       |
| soup:walls           | false            | false             | false          |                                                                                                                                                       |
| soup:washed_out      | false            | false             | false          | Currently broken.                                                                                                                                     |
| soup:watermelon      | false            | false             | false          |                                                                                                                                                       |
| soup:windows         | false            | false             | false          | That's just funny, could be cool to do an os check and have a per-os texture. It does cover the screen, however it's not major.                       |
| soup:xor             | false            | false             | false          |                                                                                                                                                       |
| soup:zigzag          | true             | false             | false          | Moves where ui elements are visually.                                                                                                                 |

> Soup shaders to test over ui: `soup:ascii`, `soup:dither`, `soup:quilted`, `soup:stern`, `soup:plasma`, `soup:rotate`, `soup:washed_out`